### PR TITLE
Health check shouldn't be used as part of AKS migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ COPY lib/applicationinsights-agent-2.3.1.jar lib/AI-Agent.xml /opt/app/
 
 WORKDIR /opt/app
 
-HEALTHCHECK --interval=100s --timeout=100s --retries=10 CMD http_proxy="" wget -q http://localhost:9001/health || exit 1
-
 EXPOSE 9001
 
 CMD ["finrem-payment-service.jar"]


### PR DESCRIPTION
This will be handled by liveness and readiness checks in K8s.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
