### PR TITLE
Api cleanup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/FeeLookupController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/FeeLookupController.java
@@ -20,7 +20,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 @RequiredArgsConstructor
 @RequestMapping(value = "/payments")
 @Slf4j
-@SuppressWarnings("unchecked")
 public class FeeLookupController {
     private final FeeService feeService;
 

--- a/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/FeeLookupController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/FeeLookupController.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.reform.finrem.payments.controllers;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.finrem.payments.config.ApplicationTypeEnumConverter;
 import uk.gov.hmcts.reform.finrem.payments.model.ApplicationType;
 import uk.gov.hmcts.reform.finrem.payments.model.fee.FeeResponse;
@@ -29,6 +30,7 @@ public class FeeLookupController {
     }
 
     @SuppressWarnings("unchecked")
+    @ApiOperation("Return fee amount for application type (consented/contested)")
     @GetMapping(path = "/fee-lookup", produces = APPLICATION_JSON)
     public FeeResponse feeLookup(@RequestParam(value = "application-type") ApplicationType applicationType) {
         log.info("Received request for FEE lookup, applicationType = {} ", applicationType);

--- a/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAPaymentController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAPaymentController.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.reform.finrem.payments.controllers;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.finrem.payments.model.pba.payment.PaymentRequest;
 import uk.gov.hmcts.reform.finrem.payments.model.pba.payment.PaymentResponse;
 import uk.gov.hmcts.reform.finrem.payments.service.PBAPaymentService;
@@ -20,6 +21,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 public class PBAPaymentController {
     private final PBAPaymentService pbaPaymentService;
 
+    @ApiOperation("Process Solicitor Pay By Account (PBA) payment")
     @PostMapping(path = "/pba-payment", consumes = APPLICATION_JSON, produces = APPLICATION_JSON)
     public PaymentResponse pbaPayment(
             @RequestHeader(value = "Authorization") String authToken,

--- a/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAValidateController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAValidateController.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.reform.finrem.payments.controllers;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.PathVariable;
 import uk.gov.hmcts.reform.finrem.payments.model.pba.validation.PBAValidationResponse;
 import uk.gov.hmcts.reform.finrem.payments.service.PBAValidationService;
 
@@ -21,6 +22,7 @@ public class PBAValidateController {
     private final PBAValidationService pbaValidationService;
 
     @SuppressWarnings("unchecked")
+    @ApiOperation("Validate Solicitor Pay By Account (PBA) number for payment")
     @GetMapping(path = "/pba-validate/{pbaNumber}", produces = APPLICATION_JSON)
     public PBAValidationResponse pbaValidate(
             @RequestHeader(value = "Authorization") String authToken,

--- a/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAValidateController.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAValidateController.java
@@ -17,11 +17,9 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 @RequiredArgsConstructor
 @RequestMapping(value = "/payments")
 @Slf4j
-@SuppressWarnings("unchecked")
 public class PBAValidateController {
     private final PBAValidationService pbaValidationService;
 
-    @SuppressWarnings("unchecked")
     @ApiOperation("Validate Solicitor Pay By Account (PBA) number for payment")
     @GetMapping(path = "/pba-validate/{pbaNumber}", produces = APPLICATION_JSON)
     public PBAValidationResponse pbaValidate(

--- a/src/main/java/uk/gov/hmcts/reform/finrem/payments/error/PaymentExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/payments/error/PaymentExceptionHandler.java
@@ -12,9 +12,9 @@ import uk.gov.hmcts.reform.finrem.payments.model.pba.payment.PaymentResponse;
 
 import java.io.IOException;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 @ControllerAdvice

--- a/src/main/java/uk/gov/hmcts/reform/finrem/payments/model/pba/payment/PaymentResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/payments/model/pba/payment/PaymentResponse.java
@@ -38,10 +38,8 @@ public class PaymentResponse {
 
 
     public String getPaymentError() {
-        return Optional.ofNullable(statusHistories)
-                .map(s -> (s.size() > 0 ? s.get(0).getErrorMessage() : message))
-                .orElse(message);
-
+        return Optional.ofNullable(statusHistories).filter(s -> s.size() > 0)
+            .map(s -> s.get(0).getErrorMessage()).orElse(message);
     }
 
     public boolean isPaymentSuccess() {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAPaymentControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAPaymentControllerTest.java
@@ -11,11 +11,11 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentRequest;
-import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponse;
-import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentRequestStringContent;
 import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.PAYMENT_REF;
 import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.PAYMENT_SUCCESS_STATUS;
+import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentRequest;
+import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentRequestStringContent;
+import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponse;
 
 @WebMvcTest(PBAPaymentController.class)
 public class PBAPaymentControllerTest extends BaseControllerTest {

--- a/src/test/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAValidateControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/payments/controllers/PBAValidateControllerTest.java
@@ -10,8 +10,8 @@ import javax.ws.rs.core.MediaType;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/uk/gov/hmcts/reform/finrem/payments/error/PaymentExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/payments/error/PaymentExceptionHandlerTest.java
@@ -14,17 +14,17 @@ import java.nio.charset.Charset;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.springframework.http.HttpStatus.OK;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentDuplicateError;
-import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponseClient422Error;
-import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponseClient404Error;
 import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponseClient401Error;
+import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponseClient404Error;
+import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponseClient422Error;
 import static uk.gov.hmcts.reform.finrem.payments.SetUpUtils.paymentResponseErrorToString;
 
 @RunWith(MockitoJUnitRunner.class)


### PR DESCRIPTION
- Added @ApiOperation() to all endpoints with a description of what the endpoint does to make out API more clear
- Replaced "@RequestMapping()" with action specific annotation. For example: "method = POST, value = "/dn-submitted")