### PR TITLE
Standardise F & P urls

### DIFF
--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,7 +1,7 @@
 vault_section = "prod"
 capacity = "2"
 idam_api_url = "https://idam-api.platform.hmcts.net"
-fees_api_url = "https://fees-register-api.platform.hmcts.net"
+fees_api_url = "http://fees-register-api-prod.service.core-compute-prod.internal"
 prd_api_url = "http://rd-professional-api-prod.service.core-compute-prod.internal"
 payment_api_url = "http://payment-api-prod.service.core-compute-prod.internal"
 ssl_verification_enabled = true


### PR DESCRIPTION
As part of migrating fees and pay apps to AKS we need to standardise on only one url,

We've ran a report and nearly 3x the number of apps are using the standard URLs, so moving the other apps back to the standard ones